### PR TITLE
Several breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,6 @@ nix = "0.17.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["consoleapi", "fileapi", "handleapi", "impl-default", "namedpipeapi", "processthreadsapi", "synchapi", "winbase", "winerror", "winnt"] }
-lazy_static = "1.4.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 #![cfg_attr(windows, feature(osstring_ascii))]
+//! TODO: Library Docs
+//! 
+
+
 
 #[cfg(unix)]
 mod unix;
@@ -6,5 +10,15 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
+#[cfg(test)]
+mod tests;
+
 mod wrappers;
 pub use wrappers::{Command, PtyProcess, PtyReader, PtyWriter};
+
+pub mod os {
+    #[cfg(unix)]
+    pub mod unix {
+        pub use crate::unix::PtyProcessExt;
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,48 @@
+use crate::Command;
+use std::io::{Read, Write};
+
+cfg_if::cfg_if! {
+    if #[cfg(unix)] {
+        const CAT: &str = "cat";
+        const CAT_ARGS: &[&str] = &[];
+        const SHELL: &str = "bash";
+    } else if #[cfg(windows)] {
+        const CAT: &str = "cmd";
+        const CAT_ARGS: &[&str] = &["/C", "type"];
+        const SHELL: &str = "cmd";
+    }
+}
+
+const ONE_SECOND: std::time::Duration = std::time::Duration::from_secs(1);
+
+#[test]
+fn test_show_file_contents() {
+    const DATA: &str = "testing echo file contents";
+    let f = {
+        let mut f = tempfile::NamedTempFile::new().expect("failed to create tempfile");
+        write!(f, "{}", DATA).expect("failed to write to tempfile");
+        f
+    };
+    let mut p = Command::new(CAT).args(CAT_ARGS).arg(f.path()).spawn_pty().unwrap();
+    std::thread::sleep(ONE_SECOND);
+    let mut buf = [0; 1024];
+    p.read(&mut buf[..]).expect("Failed to read from pty process");
+    let s = String::from_utf8_lossy(&buf[..]);
+    assert!(s.contains(DATA));
+    p.try_wait().expect("failed to try_wait").expect("failed to get exit status");
+}
+#[test]
+fn test_echo_in_shell() {
+    let mut p = Command::new(SHELL).spawn_pty().unwrap();
+    let bytes = "echo Hello, World!\r\n".as_bytes();
+    p.write_all(bytes).expect("Failed to write to process");
+    std::thread::sleep(ONE_SECOND);
+    let mut buf = [0; 1024];
+    p.read(&mut buf[..]).expect("Failed to read from process");
+    let s = String::from_utf8_lossy(&buf[..]);
+    assert_eq!(2, s.lines().filter(|s| s.contains("Hello, World")).count());
+    let bytes = "exit\r\n".as_bytes();
+    p.write_all(bytes).expect("Failed to write exit to process");
+    std::thread::sleep(ONE_SECOND);
+    p.try_wait().expect("failed to try_wait").expect("failed to get exit status");
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,15 +34,23 @@ fn test_show_file_contents() {
 #[test]
 fn test_echo_in_shell() {
     let mut p = Command::new(SHELL).spawn_pty().unwrap();
-    let bytes = "echo Hello, World!\r\n".as_bytes();
+    let bytes = b"echo Hello, World!\r\n";
     p.write_all(bytes).expect("Failed to write to process");
     std::thread::sleep(ONE_SECOND);
     let mut buf = [0; 1024];
     p.read(&mut buf[..]).expect("Failed to read from process");
     let s = String::from_utf8_lossy(&buf[..]);
     assert_eq!(2, s.lines().filter(|s| s.contains("Hello, World")).count());
-    let bytes = "exit\r\n".as_bytes();
+    let bytes = b"exit\r\n";
     p.write_all(bytes).expect("Failed to write exit to process");
     std::thread::sleep(ONE_SECOND);
     p.try_wait().expect("failed to try_wait").expect("failed to get exit status");
+}
+#[test]
+fn test_exit_with_code() {
+    let mut p = Command::new(SHELL).spawn_pty().unwrap();
+    let bytes = b"exit 42\r\n";
+    p.write_all(bytes).expect("Failed to write to process");
+    let exit_status = p.try_wait_timeout(ONE_SECOND).expect("Process wait failed").expect("Process did not exit");
+    assert_eq!(exit_status.code().unwrap(), 42);
 }

--- a/src/windows_pipe.rs
+++ b/src/windows_pipe.rs
@@ -1,14 +1,17 @@
 use winapi::um::{
     namedpipeapi::CreatePipe,
     fileapi::{ReadFile, FlushFileBuffers, WriteFile},
-    handleapi::CloseHandle,
-    winnt::HANDLE,
+    handleapi::{CloseHandle, DuplicateHandle},
+    processthreadsapi::GetCurrentProcess,
+    winnt::{DUPLICATE_SAME_ACCESS, HANDLE},
 };
+
+use winapi::shared::minwindef::FALSE;
 
 use std::{
     ptr,
     io::{self, Read, Write},
-    // os::windows::io::AsRawHandle,
+    os::windows::io::{AsRawHandle, FromRawHandle},
 };
 
 fn last_error() -> io::Error { io::Error::last_os_error() }
@@ -21,11 +24,64 @@ pub struct Receiver {
     handle: HANDLE,
 }
 
-// Send is safe iff Sender and Receiver cannot
-// be duplicated in any (safe) way. All Reads
-// and Writes are blocking operations.
+// Safety:
+// Sender and Receiver's only purpose is to wrap a handle and call WriteFile and ReadFile, respectively.
+// WriteFile and ReadFile are thread-safe, even if pipe is opened in synchronous mode and using non-overlapped
+// operations.
 unsafe impl Send for Sender {}
+unsafe impl Sync for Sender {}
 unsafe impl Send for Receiver {}
+unsafe impl Sync for Receiver {}
+
+impl Write for &Sender {
+    fn flush(&mut self) -> io::Result<()> {
+        let r = unsafe {
+            FlushFileBuffers(self.handle)
+        };
+        if r == 0 {
+            Err(io::Error::last_os_error())?;
+        }
+        Ok(())
+    }
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut written: u32 = 0;
+        let r = unsafe {
+            WriteFile(self.handle, buf.as_ptr().cast(), buf.len() as u32, &mut written, ptr::null_mut())
+        };
+        if r == 0 {
+            Err(last_error())?;
+        }
+        Ok(written as usize)
+    }
+}
+
+impl Read for &Receiver {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut read: u32 = 0;
+        let r = unsafe {
+            ReadFile(self.handle, buf.as_mut_ptr().cast(), buf.len() as u32, &mut read, ptr::null_mut())
+        };
+        if r == 0 {
+            Err(last_error())?;
+        }
+        Ok(read as usize)
+    }
+}
+
+impl Write for Sender {
+    fn flush(&mut self) -> io::Result<()> {
+        (&*self).flush()
+    }
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (&*self).write(buf)
+    }
+}
+
+impl Read for Receiver {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (&*self).read(buf)
+    }
+}
 
 impl Drop for Sender {
     fn drop(&mut self) {
@@ -41,51 +97,54 @@ impl Drop for Receiver {
     }
 }
 
-impl Write for Sender {
-    fn flush(&mut self) -> io::Result<()> {
-        let r = unsafe {
-            FlushFileBuffers(self.handle)
-        };
-        if r == 0 {
-            Err(io::Error::last_os_error())?;
-        }
-        Ok(())
-    }
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut written = 0;
-        let r = unsafe {
-            WriteFile(self.handle, buf.as_ptr().cast(), buf.len() as u32, &mut written, ptr::null_mut())
-        };
-        if r == 0 {
-            Err(last_error())?;
-        }
-        Ok(written as usize)
-    }
-}
-
-impl Read for Receiver {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut read = 0;
-        let r = unsafe {
-            ReadFile(self.handle, buf.as_mut_ptr().cast(), buf.len() as u32, &mut read, ptr::null_mut())
-        };
-        if r == 0 {
-            Err(last_error())?;
-        }
-        Ok(read as usize)
-    }
-}
-
 impl Sender {
-    pub fn as_raw_handle(&self) -> HANDLE {
-        self.handle
+    /// Try to clone the Sender
+    pub fn try_clone(&self) -> io::Result<Self> {
+        let handle = try_clone_handle(self.handle)?;
+        Ok(Self { handle })
+    }
+}
+
+impl AsRawHandle for Sender {
+    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
+        self.handle.cast()
+    }
+}
+
+impl FromRawHandle for Sender {
+    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> Self {
+        Self { handle }
     }
 }
 
 impl Receiver {
-    pub fn as_raw_handle(&self) -> HANDLE {
-        self.handle
+    /// Try to clone the Receiver
+    pub fn try_clone(&self) -> io::Result<Self> {
+        let handle = try_clone_handle(self.handle)?;
+        Ok(Self { handle })
     }
+}
+
+impl AsRawHandle for Receiver {
+    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
+        self.handle.cast()
+    }
+}
+
+impl FromRawHandle for Receiver {
+    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> Self {
+        Self { handle }
+    }
+}
+
+fn try_clone_handle(handle: HANDLE) -> io::Result<HANDLE> {
+    let proc = unsafe { GetCurrentProcess() };
+    let mut new_handle = ptr::null_mut();
+    let r = unsafe { DuplicateHandle(proc, handle, proc, &mut new_handle, 0 , FALSE, DUPLICATE_SAME_ACCESS) };
+    if r == 0 {
+        Err(last_error())?;
+    }
+    Ok(new_handle)
 }
 
 pub fn unnamed() -> io::Result<(Sender, Receiver)> {
@@ -100,4 +159,194 @@ pub fn unnamed() -> io::Result<(Sender, Receiver)> {
     let tx = Sender { handle: tx };
     let rx = Receiver { handle: rx };
     Ok((tx, rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    #[test]
+    fn basic_pipe() {
+        let (mut tx, mut rx) = super::unnamed().unwrap();
+        let all_bytes= (0..=255).collect::<Vec<_>>();
+        let mut out_buf = [0; 512];
+        tx.write_all(&all_bytes).unwrap();
+        assert_eq!(256, rx.read(&mut out_buf).unwrap());
+        assert_eq!(&out_buf[..256], &all_bytes[..]);
+    }
+    
+    #[test]
+    fn pipe_writer_reader_threads() {
+        let (mut tx, mut rx) = super::unnamed().unwrap();
+        let all_bytes= (0..=255).collect::<Vec<_>>();
+        let all_bytes2 = all_bytes.clone();
+        let mut out_buf = Vec::new();
+        let send = std::thread::spawn(move|| tx.write_all(&all_bytes2).unwrap());
+        let recv = std::thread::spawn(move|| {
+            let mut byte = [0];
+            loop { match rx.read(&mut byte) {
+                Ok(1) => out_buf.push(byte[0]),
+                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => break,
+                Ok(n) => panic!("Expected to read 1 byte, got {}", n),
+                res @ Err(_) => res.map(drop).unwrap(),
+            }}
+            out_buf
+        });
+        send.join().unwrap();
+        assert_eq!(all_bytes, recv.join().unwrap());
+    }
+
+    #[test]
+    fn threaded_pipe_multiple_writers_readers() {
+        fn spawn_writers(n_threads: u8, mut tx: &'static super::Sender) -> Vec<std::thread::JoinHandle<()>> {
+            assert!(n_threads > 1);
+            let bytes_per_thread = (256 / n_threads as usize) as u8;
+            let mut bufs = Vec::new();
+            for i in 0..n_threads-1 {
+                let v: Vec<u8> = ((i * bytes_per_thread)..((i+1)*bytes_per_thread)).collect();
+                bufs.push(v);
+            }
+            let v: Vec<u8> = (((n_threads - 1) * bytes_per_thread)..=255).collect();
+            bufs.push(v);
+
+            bufs.into_iter().map(|buf| std::thread::spawn(move|| tx.write_all(&buf).unwrap())).collect()
+        }
+        fn spawn_readers(n_threads: u8, mut rx: &'static super::Receiver) -> Vec<std::thread::JoinHandle<Vec<u8>>> {
+            let bufs = vec![Vec::with_capacity(256); n_threads as usize];
+
+            bufs.into_iter().map(|mut buf| std::thread::spawn(move|| {
+                let mut bytes = [0; 256];
+                loop { match rx.read(&mut bytes) {
+                    Ok(n) => buf.extend_from_slice(&bytes[..n]),
+                    Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => break,
+                    res @ Err(_) => res.map(drop).unwrap(),
+                }}
+                buf
+            })).collect()
+        }
+        
+        let all_bytes= (0..=255).collect::<Vec<_>>();
+
+        for n_writers  in 2..=8 {
+            for n_readers in 1..=8 {
+                println!("testing with {} writers and {} readers", n_writers, n_readers);
+                let (tx, rx) = super::unnamed().unwrap();
+                let rx = Box::leak(Box::new(rx));
+                let tx = Box::leak(Box::new(tx));
+                let rx_ptr = rx as *mut _;
+                let tx_ptr = tx as *mut _;
+
+                let readers = spawn_readers(n_readers, rx);
+                let writers = spawn_writers(n_writers, tx);
+
+                for thread in writers { thread.join().unwrap() }
+                drop(unsafe {
+                    Box::from_raw(tx_ptr)
+                });
+
+                let mut final_buf = Vec::new();
+                for (i, thread) in readers.into_iter().enumerate() {
+                    let buf = thread.join().unwrap();
+                    println!("thread {} had {} items", i, buf.len());
+                    final_buf.extend(buf);
+                }
+                final_buf.sort_unstable();
+                assert_eq!(final_buf, all_bytes);
+                drop(unsafe { Box::from_raw(rx_ptr) } );
+            }
+        }
+    }
+    
+    #[test]
+    fn threaded_pipe_multiple_writers_readers_lots_of_data() {
+        const TWO_MEGABYTES: usize = 2 * 1024 * 1024;
+
+        fn spawn_writers(n_threads: u8, mut tx: &'static super::Sender) -> Vec<std::thread::JoinHandle<()>> {
+            let mut bufs = Vec::new();
+            for i in 0..n_threads {
+                let v = vec![i; TWO_MEGABYTES];
+                bufs.push(v);
+            }
+
+            bufs.into_iter().map(|buf| std::thread::spawn(move|| tx.write_all(&buf).unwrap())).collect()
+        }
+        fn spawn_readers(n_threads: u8, mut rx: &'static super::Receiver) -> Vec<std::thread::JoinHandle<Vec<u8>>> {
+            let bufs = vec![Vec::with_capacity(256); n_threads as usize];
+
+            bufs.into_iter().map(|mut buf| std::thread::spawn(move|| {
+                let mut bytes = [0; 4096];
+                loop { match rx.read(&mut bytes) {
+                    Ok(n) => buf.extend_from_slice(&bytes[..n]),
+                    Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => break,
+                    res @ Err(_) => res.map(drop).unwrap(),
+                }}
+                buf
+            })).collect()
+        }
+
+        let n_writers = 8;
+        let n_readers = 8;
+        println!("testing with {} writers and {} readers", n_writers, n_readers);
+        let (tx, rx) = super::unnamed().unwrap();
+        let rx = Box::leak(Box::new(rx));
+        let tx = Box::leak(Box::new(tx));
+        let rx_ptr = rx as *mut _;
+        let tx_ptr = tx as *mut _;
+
+        let readers = spawn_readers(n_readers, rx);
+        let writers = spawn_writers(n_writers, tx);
+
+        for thread in writers { thread.join().unwrap() }
+        drop(unsafe {
+            Box::from_raw(tx_ptr)
+        });
+
+        let mut final_buf = Vec::new();
+        for (i, thread) in readers.into_iter().enumerate() {
+            let buf = thread.join().unwrap();
+            println!("thread {} had {} items", i, buf.len());
+            final_buf.extend(buf);
+        }
+        drop(unsafe { Box::from_raw(rx_ptr) } );
+        let mut counts = std::collections::HashMap::new();
+        for x in final_buf {
+            *counts.entry(x).or_insert(0usize) += 1;
+        }
+        let mut found = vec![false; n_writers as usize];
+        for (id, count) in counts {
+            if !found[id as usize] {
+                println!("Found data from sender {}", id);
+                found[id as usize] = true;
+            }
+            assert_eq!(count, TWO_MEGABYTES);
+        }
+        assert!(found.into_iter().all(|x| x));
+    }
+
+    #[test]
+    fn pipe_clones() {
+        {
+            let (mut tx, mut rx) = super::unnamed().unwrap();
+            drop(tx.try_clone().unwrap());
+            drop(rx.try_clone().unwrap());
+            let all_bytes= (0..=255).collect::<Vec<_>>();
+            let mut out_buf = [0; 512];
+            tx.write_all(&all_bytes).unwrap();
+            assert_eq!(256, rx.read(&mut out_buf).unwrap());
+            assert_eq!(&out_buf[..256], &all_bytes[..]);
+            drop(tx);
+            assert!(rx.read(&mut out_buf).is_err());
+        }
+        {
+            let (mut tx, mut rx) = super::unnamed().unwrap();
+            drop(tx.try_clone().unwrap());
+            drop(rx.try_clone().unwrap());
+            let all_bytes= (0..=255).collect::<Vec<_>>();
+            let mut out_buf = [0; 512];
+            tx.write_all(&all_bytes).unwrap();
+            assert_eq!(256, rx.read(&mut out_buf).unwrap());
+            assert_eq!(&out_buf[..256], &all_bytes[..]);
+            drop(rx);
+            assert!(tx.write(&out_buf).is_err());
+        }
+    }
 }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,16 +1,17 @@
-use cfg_if::cfg_if;
-
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(unix)] {
         use std::process::Command as InnerCommand;
         use crate::unix::PtyProcess as InnerPtyProcess;
         use std::fs::File as InnerPtyReader;
         use std::fs::File as InnerPtyWriter;
+        use std::os::unix::io::{AsRawFd, RawFd};
+        use nix::sys::signal::Signal;
     } else if #[cfg(windows)] {
         use crate::windows::Command as InnerCommand;
         use crate::windows::PtyProcess as InnerPtyProcess;
         use crate::windows::pipe::Receiver as InnerPtyReader;
         use crate::windows::pipe::Sender as InnerPtyWriter;
+        use std::os::windows::io::{AsRawHandle, RawHandle};
     }
 }
 
@@ -24,22 +25,29 @@ use std::{
     time,
 };
 
+// Assertions over trait impls to ensure common behavior on all platforms
 static_assertions::assert_impl_all!(Command: Send, Unpin);
 static_assertions::assert_not_impl_any!(Command: Sync);
 
-static_assertions::assert_impl_all!(PtyProcess: Send, Unpin);
-static_assertions::assert_not_impl_any!(PtyProcess: Sync);
-
-static_assertions::assert_impl_all!(PtyReader: Read, Send, Unpin);
-static_assertions::assert_not_impl_any!(PtyReader: Write, Sync);
-
-static_assertions::assert_impl_all!(PtyWriter: Write, Send, Unpin);
-static_assertions::assert_not_impl_any!(PtyWriter: Read, Sync);
+static_assertions::assert_impl_all!(PtyProcess: Read, Write, Send, Sync, Unpin);
+static_assertions::assert_impl_all!(PtyReader: Read, Send, Sync, Unpin);
+static_assertions::assert_impl_all!(PtyWriter: Write, Send, Sync, Unpin);
 
 /// A Command used to start a PtyProcess. Similar API as std's Command.
 pub struct Command {
     pub(crate) inner: InnerCommand,
+    // std::process::Command (used by unix) is not Sync.
+    // This ensures our Command is not Sync on Windows.
     _not_sync: PhantomData<std::cell::Cell<()>>,
+}
+
+/// A PtyProcess represents a process which is using a PseudoTerminal to handle IO.
+///
+/// The child process and pseudoterminal are destroyed when this object is dropped.
+/// A timeout can be configured to wait for the process to end before returning from drop.
+/// See PtyProcess::set_drop_timeout
+pub struct PtyProcess {
+    inner: InnerPtyProcess,
 }
 
 impl Command {
@@ -49,13 +57,16 @@ impl Command {
             _not_sync: PhantomData,
         }
     }
+    /// Creates a new Command with the specified program. Same as std's Command::new
     pub fn new<S: AsRef<OsStr>>(program: S) -> Command {
         Self::from_inner(InnerCommand::new(program))
     }
+    /// Appends an argument to the Command to be executed. Same as std's Command::arg
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Command {
         self.inner.arg(arg.as_ref());
         self
     }
+    /// Appends multiple arguments to the Command to be executed. Same as std's Command::args
     pub fn args<I, S>(&mut self, args: I) -> &mut Command
     where
         I: IntoIterator<Item = S>,
@@ -66,6 +77,7 @@ impl Command {
         }
         self
     }
+    /// Sets an environment variable which will be visible to the child process. Same as std's Command::env
     pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Command
     where
         K: AsRef<OsStr>,
@@ -74,6 +86,7 @@ impl Command {
         self.inner.env(key.as_ref(), val.as_ref());
         self
     }
+    /// Sets multiple environment variables which will be visible to the child process. Same as std's Command::envs
     pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Command
     where
         I: IntoIterator<Item = (K, V)>,
@@ -85,18 +98,22 @@ impl Command {
         }
         self
     }
+    /// Removes an environment variable from the child process's view. Same as std's Command::env_remove
     pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Command {
         self.inner.env_remove(key.as_ref());
         self
     }
+    /// Remove all environment variables from the child process's view. Same as std's Command::env_clear
     pub fn env_clear(&mut self) -> &mut Command {
         self.inner.env_clear();
         self
     }
+    /// Sets the initial current working directory for the child process. Same as std's Command::current_dir
     pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Command {
         self.inner.current_dir(dir.as_ref());
         self
     }
+    /// Spawns the process in a new Pseudoterminal.
     pub fn spawn_pty(&mut self) -> std::io::Result<PtyProcess> {
         PtyProcess::new(self)
     }
@@ -108,54 +125,44 @@ impl fmt::Debug for Command {
     }
 }
 
-pub struct PtyProcess {
-    inner: InnerPtyProcess,
-    _not_sync: PhantomData<std::cell::Cell<()>>,
-}
-
 impl PtyProcess {
     fn from_inner(inner: InnerPtyProcess) -> Self {
         Self {
             inner,
-            _not_sync: PhantomData
         }
     }
+    /// Spawns a new PtyProcess using the provided Command.
     pub fn new(cmd: &mut Command) -> std::io::Result<Self> {
         InnerPtyProcess::spawn(&mut cmd.inner).map(Self::from_inner)
     }
+    /// Returns the Process ID of the child process.
     pub fn id(&self) -> u32 {
         self.inner.id()
     }
+    /// Immediately and forcibly terminate the child process.
     pub fn kill(&mut self) -> std::io::Result<()> {
         self.inner.kill()
     }
+    /// Attempt to wait for the process to stop without blocking.
     pub fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
         self.inner.try_wait()
     }
-    /// Waits for a process to stop, returning if the timeout expires.
-    /// 
-    /// #Return
-    /// 
-    /// Returns Ok(Some(...)) if the process is halted before the timeout expires.
-    /// Returns Ok(None) if the process is not halted before the timeout.
-    /// Returns Err(...) only if an error occurs.
+    /// Attempt to wait for the process to stop, blocking up to the timeout before returning.
     pub fn try_wait_timeout(&mut self, timeout: time::Duration) -> std::io::Result<Option<ExitStatus>> {
         self.inner.try_wait_timeout(timeout)
     }
+    /// Attempt to wait for the process to stop, blocking as long as is required.
     pub fn wait(&mut self) -> std::io::Result<ExitStatus> {
         self.inner.wait()
     }
-    pub fn take_reader(&mut self) -> Option<PtyReader> {
-        self.inner.take_reader().map(PtyReader::from_inner)
+    /// Attempt to clone the PtyReader from this process.
+    pub fn try_clone_reader(&self) -> std::io::Result<PtyReader> {
+        self.inner.try_clone_reader().map(PtyReader::from_inner)
     }
-    pub fn take_writer(&mut self) -> Option<PtyWriter> {
-        self.inner.take_writer().map(PtyWriter::from_inner)
+    /// Attempt to clone the PtyWriter from this process.
+    pub fn try_clone_writer(&self) -> std::io::Result<PtyWriter> {
+        self.inner.try_clone_writer().map(PtyWriter::from_inner)
     }
-    // pub fn take_io_handles(&mut self) -> Option<(PtyReader, PtyWriter)> {
-    //     let reader = self.take_reader()?;
-    //     let writer = self.take_writer()?;
-    //     Some((reader, writer))
-    // }
 
     /// Setting this value changes the behavior of dropping the PtyProcess. The default timeout value is 0.
     ///
@@ -170,17 +177,49 @@ impl PtyProcess {
     }
 }
 
+impl Read for &PtyProcess {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (&self.inner).read(buf)
+    }
+}
+
+impl Write for &PtyProcess {
+    fn flush(&mut self) -> std::io::Result<()> {
+        (&self.inner).flush()
+    }
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        (&self.inner).write(buf)
+    }
+}
+
+impl Read for PtyProcess {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (&*self).read(buf)
+    }
+}
+
+impl Write for PtyProcess {
+    fn flush(&mut self) -> std::io::Result<()> {
+        (&*self).flush()
+    }
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        (&*self).write(buf)
+    }
+}
+
 pub struct PtyReader {
     inner: InnerPtyReader,
-    _not_sync: PhantomData<std::cell::Cell<()>>,
 }
 
 impl PtyReader {
     fn from_inner(inner: InnerPtyReader) -> Self {
         Self {
             inner,
-            _not_sync: PhantomData,
         }
+    }
+    pub fn try_clone(&self) -> std::io::Result<Self> {
+        let cloned = self.inner.try_clone()?;
+        Ok(Self::from_inner(cloned))
     }
 }
 
@@ -189,18 +228,19 @@ impl Read for PtyReader {
         self.inner.read(buf)
     }
 }
-
 pub struct PtyWriter {
     inner: InnerPtyWriter,
-    _not_sync: PhantomData<std::cell::Cell<()>>,
 }
 
 impl PtyWriter {
     fn from_inner(inner: InnerPtyWriter) -> Self {
         Self {
             inner,
-            _not_sync: PhantomData
         }
+    }
+    pub fn try_clone(&self) -> std::io::Result<Self> {
+        let cloned = self.inner.try_clone()?;
+        Ok(Self::from_inner(cloned))
     }
 }
 
@@ -210,5 +250,40 @@ impl Write for PtyWriter {
     }
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for PtyReader {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for PtyWriter {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandle for PtyReader {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.inner.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandle for PtyWriter {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.inner.as_raw_handle()
+    }
+}
+
+#[cfg(unix)]
+impl crate::os::unix::PtyProcessExt for crate::PtyProcess {
+    fn signal(&mut self, signal: impl Into<Option<Signal>>) -> nix::Result<()> {
+        self.inner.signal(signal)
     }
 }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -155,12 +155,12 @@ impl PtyProcess {
     pub fn wait(&mut self) -> std::io::Result<ExitStatus> {
         self.inner.wait()
     }
-    /// Attempt to clone the PtyReader from this process.
+    /// Get a reference to the reader for this process.
     pub fn reader(&self) -> &PtyReader {
         self.inner.reader()
     }
-    /// Attempt to clone the PtyWriter from this process.
-    pub fn try_clone_writer(&self) -> &PtyWriter {
+    /// Get a reference to the writer for this process.
+    pub fn writer(&self) -> &PtyWriter {
         self.inner.writer()
     }
 


### PR DESCRIPTION
* Made PtyReader, PtyWriter Send + Sync
* Added some tests
* Fixed drop implementations
* Added unix trait for sending signals
* Added basic documentation (still need crate-level docs)
* Various cleanups

Before merging:

- [ ] Set rexpect to depend on specific commit of this repo to avoid breaking rexpect

After merging:

- [ ] Fix rexpect to work with this commit and test it
